### PR TITLE
Type month: Trigger change onSelect

### DIFF
--- a/dateInput.js
+++ b/dateInput.js
@@ -309,6 +309,8 @@
 							selectedDate = new Date(inst.selectedYear, inst.selectedMonth, 1);
 							t.datepicker('setDate', selectedDate);
 							inst.input.blur();
+
+							inst.input.trigger( "change" ); // fire the change event
 						}
 					});
 					if (pickerSettings.maxDate) {


### PR DESCRIPTION
If `onSelect()` is set, datepicker_ui not triggering on change automatically.
We need to trigger change for ublaboo datagrid